### PR TITLE
add git safe directory in action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,8 @@
 set -e
 set -o pipefail
 
+/usr/bin/git config --global --add safe.directory /github/workspace
+
+git status
+
 julia /format.jl "$@"

--- a/format.jl
+++ b/format.jl
@@ -120,6 +120,9 @@ function parse_opts!(args::Vector{String})
     return opts
 end
 
+diff_before = Cmd(`git diff --name-only`) |> read |> String
+@assert diff_before ==""
+
 opts = parse_opts!(ARGS)
 if isempty(ARGS) || haskey(opts, :help)
     write(stdout, help)


### PR DESCRIPTION
I have had a strange issue appear when using this action in my repo.  The formatter runs successfully, but git complains that it is not in a repo when checking if files have changed.  The error occurs on [line 132 of `format.jl`](https://github.com/julia-actions/julia-format/blob/8223b4c0ac72e284e4acc5b3c37c888c864eef6c/format.jl#L132).

Here is an example run that didn't work: https://github.com/musoke/UltraDark.jl/actions/runs/4238135156/jobs/7364871794

And the corresponding configuration:
```
name: JuliaFormatter

on:
  push:
    branches:
      - 'main'
      - 'release-'
    tags: '*'
  pull_request:

jobs:
  format:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    - name: ls -a to check for .git
      run: ls -a
    - uses: julia-actions/julia-format@master
      with:
        args: -v .
```

and the error (snipped a lot of output):

```
...
Formatting /github/workspace/test/summary.jl
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>

Diff output format options
...
...
ERROR: LoadError: failed process: Process(`git diff --name-only`, ProcessExited(129)) [129]

Stacktrace:
 [1] pipeline_error
   @ ./process.jl:565 [inlined]
 [2] read(cmd::Cmd)
   @ Base ./process.jl:449
 [3] |>(x::Cmd, f::typeof(read))
   @ Base ./operators.jl:911
 [4] top-level scope
   @ //format.jl:132
in expression starting at /format.jl:132
``` 



This seems to be because of how directories are nested in the docker environment. See for example https://github.com/actions/checkout/issues/363#issuecomment-1163942488


I changed `entrypoint.sh` to explicitly mark the directory as safe so git agrees to run.  This fixed my CI: https://github.com/musoke/UltraDark.jl/actions/runs/4238608466
I also added a check that `git diff --name-only` has empty output before the formatter is run.

 ----

It could well be that I have done something silly.