### PR TITLE
add depot caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: julia-actions/cache@v1
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'import Pkg; Pkg.add("JuliaFormatter")'

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/cache@v1
     - name: 'Install JuliaFormatter'
       run: |
         julia -e '


### PR DESCRIPTION
A lot of time is spent precompiling JuliaFormatter vs. time running the formatter. 
It might be worth always caching the depot