### PR TITLE
feat: add inputs for JF version and suggester label

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,25 @@
 
 ## Setup workflow with `julia-format` action
 
+> [!IMPORTANT]
+> Starting with v3 of this action, unformatted code in files that are not part of the current PR will cause the action to fail.
+
 Save the following code as `Format.yml` in the `.github/workflows/` directory in your repository.
 
 ```yaml
 name: Format suggestions
 on:
   pull_request:
+    # this argument is not required if you don't use the `suggestion-label` input
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
 jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/julia-format@v2
+      - uses: julia-actions/julia-format@v3
+        with:
+          version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
+          suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs
 ```
 
 With this workflow, [reviewdog](https://github.com/reviewdog/reviewdog) will automatically post code suggestions to pull requests in your repository, based on the formatting rules defined by [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl).

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,35 @@
 name: 'Format suggestion with JuliaFormatter.jl'
 description: "Formats your Julia files and suggest changes"
+inputs:
+  version:
+    description: 'Version of JuliaFormatter.jl. Examples: 1, 1.0, 1.0.44'
+    default: '1'
+  suggestion-label:
+    description: 'If set, suggestions will only be shown for PRs with this label applied.'
+    default: ''
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
     - uses: julia-actions/cache@v1
     - name: 'Install JuliaFormatter'
       run: |
         julia -e '
           using Pkg
-          Pkg.add("JuliaFormatter")'
+          Pkg.add(Pkg.PackageSpec(name="JuliaFormatter", version=get(ENV, "jf-version", "1")))'
       shell: bash
+      env:
+        jf-version: ${{ inputs.version }}
     - name: 'Format'
       run: |
         julia -e '
           using JuliaFormatter
-          format(".")'
+          format(".") ? exit(0) : exit(1)'
       shell: bash
     - name: 'Suggest'
       uses: reviewdog/action-suggester@v1
+      if: ${{ failure() && (inputs.suggestion-label == '' || contains( github.event.pull_request.labels.*.name, inputs.suggestion-label )) }}
       with:
         tool_name: JuliaFormatter
         fail_on_error: true


### PR DESCRIPTION
This PR adds two input arguments to the action:
- `version: 1.0.54` allows pinning JuliaFormatter.jl to a major, minor, or patch version
- `suggestion-label: 'foo'` only shows suggestions when that label is on the PR

I've also updated `setup-julia` to v2.