### PR TITLE
chore: restore behavior that lists files that need formatting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
             echo 1>&2 "Some files have not been formatted !!!"
             echo "$output"
             exit 1
-        end
+        fi
     - name: 'Suggest'
       uses: reviewdog/action-suggester@v1
       if: ${{ failure() && (inputs.suggestion-label == '' || contains( github.event.pull_request.labels.*.name, inputs.suggestion-label )) }}

--- a/action.yml
+++ b/action.yml
@@ -25,18 +25,16 @@ runs:
       run: |
         julia -e '
           using JuliaFormatter
-          format(".") ? exit(0) : exit(1)'
+          format(".")'
       shell: bash
     - name: Check for formatting errors
-      shell: julia --color=yes --project=@juliaformatter {0}
+      shell: bash
       run: |
-        out = Cmd(`git diff --name-only`) |> read |> String
-        if out == ""
-            exit(0)
-        else
-            @error "Some files have not been formatted !!!"
-            write(stdout, out)
-            exit(1)
+        output=$(git diff --name-only)
+        if [ "$output" != "" ]; then
+            echo 1>&2 "Some files have not been formatted !!!"
+            echo "$output"
+            exit 1
         end
     - name: 'Suggest'
       uses: reviewdog/action-suggester@v1

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,17 @@ runs:
           using JuliaFormatter
           format(".") ? exit(0) : exit(1)'
       shell: bash
+    - name: Check for formatting errors
+      shell: julia --color=yes --project=@juliaformatter {0}
+      run: |
+        out = Cmd(`git diff --name-only`) |> read |> String
+        if out == ""
+            exit(0)
+        else
+            @error "Some files have not been formatted !!!"
+            write(stdout, out)
+            exit(1)
+        end
     - name: 'Suggest'
       uses: reviewdog/action-suggester@v1
       if: ${{ failure() && (inputs.suggestion-label == '' || contains( github.event.pull_request.labels.*.name, inputs.suggestion-label )) }}

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         output=$(git diff --name-only)
         if [ "$output" != "" ]; then
-            echo 1>&2 "Some files have not been formatted !!!"
+            >&2 echo "Some files have not been formatted !!!"
             echo "$output"
             exit 1
         fi


### PR DESCRIPTION
Add back in the list of files that need formatting. At least the action we used to use did that.

This way, if reviewdog doesn't run, you can at least see the files that need formatting.