### PR TITLE
Set julia-actions/cache to v2 in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v2
-    - uses: julia-actions/cache@v1
+    - uses: julia-actions/cache@v2
     - name: 'Install JuliaFormatter'
       run: |
         julia -e '


### PR DESCRIPTION
Running this action gives the following warning

```
The following actions use a deprecated Node.js version and will be forced to run on node20:
actions/cache@4d4ae6ae148a43d0fd1eda1800170683e9882738, pyTooling/Actions/with-post
step@adef08d3bdef092282614f3b683897cefae82ee3. For more info: https://github.blog/changelog/2024-03-07-github
actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
because it still uses `julia-actions/cache@v1`, which ran on node 16. As I understand without updating to node20 (i.e. without updating to `julia-actions/cache@v2`) this action will not run anymore in the near future.

I think this is considered a breaking change, see for example https://github.com/julia-actions/cache/pull/117.

See also #30.