### PR TITLE
Change `fail_on_error` to `fail_level`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,4 +41,4 @@ runs:
       if: ${{ failure() && (inputs.suggestion-label == '' || contains( github.event.pull_request.labels.*.name, inputs.suggestion-label )) }}
       with:
         tool_name: JuliaFormatter
-        fail_on_error: true
+        fail_level: error


### PR DESCRIPTION
The `fail_on_error` argument of the reviewdog action is deprecated. Instead, `fail_level` should be used. See https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#rotating_light-deprecation-warnings