### PR TITLE
Run the Julia steps in a `julia` shell, and show color in the Julia steps (`julia --color=yes`)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,19 +14,17 @@ runs:
     - uses: julia-actions/setup-julia@v2
     - uses: julia-actions/cache@v2
     - name: Install JuliaFormatter
+      shell: julia --color=yes {0}
       run: |
-        julia -e '
-          using Pkg
-          Pkg.add(Pkg.PackageSpec(name="JuliaFormatter", version=get(ENV, "jf-version", "1")))'
-      shell: bash
+        using Pkg
+        Pkg.add(Pkg.PackageSpec(name="JuliaFormatter", version=get(ENV, "jf-version", "1")))
       env:
         jf-version: ${{ inputs.version }}
     - name: Format
+      shell: julia --color=yes {0}
       run: |
-        julia -e '
-          using JuliaFormatter
-          format(".")'
-      shell: bash
+        using JuliaFormatter
+        format(".")
     - name: Check for formatting errors
       shell: bash
       run: |


### PR DESCRIPTION
Changes in this PR:

- [x] Use `shell: julia --color=yes` to show colored Julia output for steps

Changes that were previously in this PR, but were moved into separate PRs:

- [x] Upgrade `julia-actions/cache` to use `v2`
    - Done in #33.
- [x] Avoid quoting step names for consistency
    - Done in #38.