### PR TITLE
Add option to format only some paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ jobs:
       - uses: julia-actions/julia-format@v4
         with:
           version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
-          suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs
+          suggestion-label: 'format-suggest' # Leave this unset or empty to show suggestions for all PRs
+          paths: 'src/, test/' # Leave this unset to format every file
 ```
 
 With this workflow, [reviewdog](https://github.com/reviewdog/reviewdog) will automatically post code suggestions to pull requests in your repository, based on the formatting rules defined by [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl).

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   suggestion-label:
     description: 'If set, suggestions will only be shown for PRs with this label applied.'
     default: ''
+  paths:
+    description: 'A comma-separated list of paths (folders or files) to be formatted'
+    default: '.'
 runs:
   using: "composite"
   steps:
@@ -45,7 +48,10 @@ runs:
       shell: julia --color=yes {0}
       run: |
         import JuliaFormatter
-        JuliaFormatter.format(".")
+        paths = strip.(split(get(ENV, "jf-paths", "."), ","))
+        JuliaFormatter.format(paths)
+      env:
+        jf-paths: ${{ inputs.paths }}
     - name: Check for formatting errors
       shell: bash
       run: |


### PR DESCRIPTION
This PR adds a new parameter to only format some folders or files instead of everything ("."). Is there a way to test this locally? Could you maybe take a look @DilumAluthge (thanks for the recent cleanup btw :pray:)?